### PR TITLE
chore: add CLI flags + debug output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/jaekwon/openpgp
+
+go 1.23.8

--- a/openpgp.go
+++ b/openpgp.go
@@ -1,15 +1,14 @@
 package main
 
 import (
-	"bufio"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
+	"flag"
 	"fmt"
 	"io"
 	"os"
-	"strconv"
 	"time"
 )
 
@@ -55,38 +54,143 @@ func next256(ent b256, last b256) (next b256) {
 }
 
 func main() {
-	fmt.Println("WARNING: This is a test implementation. The entropy source will be replaced with custom entropy.")
+	// Define flags
+	keySize := flag.Int("bits", 8192, "RSA key size in bits (default: 8192)")
+	entropy := flag.String("entropy", "", "Entropy string (dice rolls or card shuffle)")
+	debug := flag.Bool("debug", false, "Show debug information about entropy processing")
+	help := flag.Bool("help", false, "Show help message")
+	
+	// Custom usage message
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [OPTIONS]\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Options:\n")
+		flag.PrintDefaults()
+		fmt.Fprintf(os.Stderr, "\nExamples:\n")
+		fmt.Fprintf(os.Stderr, "  D20 dice (42 rolls):\n")
+		fmt.Fprintf(os.Stderr, "    %s -entropy \"4 2 20 15 8 12 3 19 7 11 16 5 14 9 1 18 10 6 13 17 20 8 15 3 11 7 19 2 14 5 16 12 9 4 1 18 6 10 13 17 20 7\"\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "  Card shuffle (52 cards):\n")
+		fmt.Fprintf(os.Stderr, "    %s -entropy \"As 4d Jh Kc Td 9h 2s 7c Qd 3h 8s Ac 5d Kh 6c Js 10h 4s 9c Ad 2h 7d Qs 3c 8h Kd 5s Jc Ah 6d 10s 4h 9d 2c 7h Qc 3d 8c Ks 5h Jd As 6s 10c 4c 9s 2d 7s Qh 3s 8d 10d\"\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "SECURITY WARNING: In production, entropy should NEVER be passed as command-line\n")
+		fmt.Fprintf(os.Stderr, "                  arguments as they are visible in process lists and shell history!\n\n")
+	}
+	
+	flag.Parse()
+	
+	// Show help if requested
+	if *help {
+		flag.Usage()
+		os.Exit(0)
+	}
+	
+	// Check if entropy was provided
+	if *entropy == "" {
+		fmt.Fprintf(os.Stderr, "ERROR: Missing entropy. Use -entropy flag to provide entropy string.\n\n")
+		flag.Usage()
+		os.Exit(1)
+	}
+	
+	// Validate key size
+	if *keySize < 1024 {
+		fmt.Fprintf(os.Stderr, "ERROR: Key size must be at least 1024 bits\n")
+		os.Exit(1)
+	}
+	
+	sz := *keySize
+	text := *entropy
+
+	fmt.Println("================================================================================")
+	fmt.Println("DEVELOPMENT MODE WARNING:")
+	fmt.Println("- Entropy is being passed via command-line argument (INSECURE!)")
+	fmt.Println("- This is ONLY for development/testing purposes")
+	fmt.Println("- Production version will read entropy securely from stdin")
+	fmt.Println("- Command-line arguments are visible in process lists and shell history!")
+	fmt.Println("================================================================================")
 	fmt.Println()
 
-	// The only entropy source is user input, and deterministic.
-	reader := bufio.NewReader(os.Stdin)
-	size, _ := reader.ReadString('\n')
-	sz, err := strconv.Atoi(size[:len(size)-1])
-	if err != nil {
-		panic(err)
-	}
-	fmt.Println("size:", sz)
-	text, _ := reader.ReadString('\n')
-	fmt.Println("read:", text)
+	fmt.Printf("Key size: %d bits\n", sz)
+	
+	inputBytes := []byte(text)
+	
+	if *debug {
+		fmt.Printf("Entropy: %s\n", text)
+		fmt.Println()
 
+		// Debug information about entropy processing
+		fmt.Println("DEBUG: === Entropy Processing Steps ===")
+		fmt.Printf("DEBUG: Input entropy string: %q\n", text)
+		fmt.Printf("DEBUG: Input length: %d bytes\n", len(text))
+		fmt.Printf("DEBUG: Input bytes (hex): %x\n", inputBytes)
+		fmt.Println()
+
+		// Show fold256 processing
+		fmt.Println("DEBUG: === fold256 Processing ===")
+		fmt.Printf("DEBUG: Folding %d bytes into 32 bytes\n", len(inputBytes))
+		
+		// Show chunk breakdown
+		chunkSize := 32
+		numChunks := (len(inputBytes) + chunkSize - 1) / chunkSize
+		fmt.Printf("DEBUG: Number of 32-byte chunks: %d\n", numChunks)
+		
+		for i := 0; i < numChunks; i++ {
+			start := i * chunkSize
+			end := min((i+1)*chunkSize, len(inputBytes))
+			chunk := inputBytes[start:end]
+			fmt.Printf("DEBUG: Chunk %d (bytes %d-%d): %x\n", i, start, end-1, chunk)
+		}
+	}
+	
+	ent := fold256(inputBytes)
+	
+	if *debug {
+		fmt.Printf("DEBUG: fold256 result: %x\n", ent)
+		fmt.Println()
+
+		// Show next256 processing
+		fmt.Println("DEBUG: === next256 PRNG Processing ===")
+		fmt.Printf("DEBUG: Initial entropy (ent): %x\n", ent)
+	}
+	
 	// Run goroutine for writing pseudo-random bytes from entropy.
 	reader2, writer := io.Pipe()
 	written := 0
 	go func() {
-		ent := fold256([]byte(text))
 		last := b256{}
+		if *debug {
+			fmt.Printf("DEBUG: Initial last value: %x\n", last)
+		}
+		
+		// First iteration details
 		next := next256(ent, last)
+		if *debug {
+			fmt.Printf("DEBUG: First next256 call:\n")
+			fmt.Printf("DEBUG:   ent XOR last = %x\n", xor(ent, last))
+			fmt.Printf("DEBUG:   SHA256 result = %x\n", next)
+		}
+		
+		iteration := 0
 		for {
 			writer.Write(next[:])
 			written += len(next)
-			fmt.Printf("writing to writer: %X (%d)\n", next, written)
+			iteration++
+			
+			// Only show debug for first few iterations
+			if *debug && iteration <= 3 {
+				fmt.Printf("DEBUG: Iteration %d: wrote %d bytes, total: %d\n", iteration, len(next), written)
+			}
+			
 			time.Sleep(time.Millisecond)
 			next = next256(ent, next)
 		}
 	}()
 
 	// Generate key using above source of random bytes...
-	fmt.Println("generating key")
+	if *debug {
+		fmt.Println()
+		fmt.Println("DEBUG: === RSA Key Generation ===")
+		fmt.Printf("DEBUG: Generating %d-bit RSA key...\n", sz)
+	} else {
+		fmt.Println("Generating RSA key...")
+	}
 
 	privateKey, err := rsa.GenerateKey(reader2, sz)
 	if err != nil {
@@ -94,7 +198,11 @@ func main() {
 		return
 	}
 
-	fmt.Println("generated key")
+	if *debug {
+		fmt.Println("DEBUG: RSA key generation complete")
+		fmt.Printf("DEBUG: Public key modulus (first 32 bytes): %x...\n", privateKey.N.Bytes()[:32])
+		fmt.Println()
+	}
 
 	der, err := x509.MarshalPKCS8PrivateKey(privateKey)
 	if err != nil {

--- a/openpgp.go
+++ b/openpgp.go
@@ -1,24 +1,22 @@
 package main
 
-// this is a test, i will replace this with custom entropy.
-
 import (
-	"io"
-	"time"
 	"bufio"
 	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/pem"
-	"strconv"
 	"fmt"
+	"io"
 	"os"
+	"strconv"
+	"time"
 )
 
 type b256 [32]byte
 
 func min(a, b int) int {
-	if a < b { 
+	if a < b {
 		return a
 	} else {
 		return b
@@ -26,11 +24,11 @@ func min(a, b int) int {
 }
 
 // x can be any length, but output is always 256 bits.
-func fold256(x []byte) (y b256) { 
-	t := (len(x)+len(y)-1) / len(y)
-	for i:=0; i<t; i++ {
+func fold256(x []byte) (y b256) {
+	t := (len(x) + len(y) - 1) / len(y)
+	for i := 0; i < t; i++ {
 		xi := b256{}
-		xs := len(y)*i
+		xs := len(y) * i
 		xe := min(len(y)*(i+1), len(x))
 		copy(xi[:], x[xs:xe])
 		y = xor(y, xi)
@@ -39,7 +37,7 @@ func fold256(x []byte) (y b256) {
 }
 
 func xor(a, b b256) (c b256) {
-	for i := 0; i<len(a); i++ {
+	for i := 0; i < len(a); i++ {
 		c[i] = a[i] ^ b[i]
 	}
 	return c
@@ -47,51 +45,18 @@ func xor(a, b b256) (c b256) {
 
 // Any hash function may have restricted range of output, so we XOR the
 // original every time, which could increase the range of output.
-// XXX test.
 func next256(ent b256, last b256) (next b256) {
 	h := sha256.New()
 	x := xor(ent, last)
 	h.Write(x[:])
 	s := h.Sum(nil)
 	copy(next[:], s)
-	fmt.Printf("ent %X last %X xor %X hash %X\n", ent, last, x, s)
 	return
 }
 
-func test() {
-	fmt.Println(min(1,2))
-	fmt.Println(min(2,1))
-	fmt.Println(fold256([]byte("a")))
-	fmt.Println(fold256([]byte("abc")))
-	fmt.Println(fold256([]byte("1234567890")))
-	fmt.Println(fold256([]byte("12345678901234567890123456789012")))
-	fmt.Println(fold256([]byte("123456789012345678901234567890122")))
-	fmt.Println(fold256([]byte("1234567890123456789012345678901212345678901234567890123456789012")))
-	fmt.Println(fold256([]byte("12345678901234567890123456789012123456789012345678901234567890121")))
-	{
-	fmt.Println("----------------------------------------")
-	a := b256{}
-	b := b256{}
-	fmt.Println(next256(a, b))
-	fmt.Println(next256(a, b))
-	b = next256(a, b)
-	fmt.Println(next256(a, b))
-	}
-
-	{
-	fmt.Println("----------------------------------------")
-	a := b256{}
-	a[0] = 0xFF
-	b := b256{}
-	fmt.Println(next256(a, b))
-	fmt.Println(next256(a, b))
-	b = next256(a, b)
-	fmt.Println(next256(a, b))
-	}
-}
-
 func main() {
-	test()
+	fmt.Println("WARNING: This is a test implementation. The entropy source will be replaced with custom entropy.")
+	fmt.Println()
 
 	// The only entropy source is user input, and deterministic.
 	reader := bufio.NewReader(os.Stdin)
@@ -119,7 +84,6 @@ func main() {
 			next = next256(ent, next)
 		}
 	}()
-
 
 	// Generate key using above source of random bytes...
 	fmt.Println("generating key")

--- a/openpgp_test.go
+++ b/openpgp_test.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestMin(t *testing.T) {
+	tests := []struct {
+		a, b int
+		want int
+	}{
+		{1, 2, 1},
+		{2, 1, 1},
+		{5, 5, 5},
+		{-1, 0, -1},
+		{100, 99, 99},
+	}
+
+	for _, tt := range tests {
+		got := min(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("min(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestXor(t *testing.T) {
+	tests := []struct {
+		name string
+		a    b256
+		b    b256
+		want b256
+	}{
+		{
+			name: "all zeros",
+			a:    b256{},
+			b:    b256{},
+			want: b256{},
+		},
+		{
+			name: "xor with self gives zeros",
+			a:    b256{0xFF, 0x12, 0x34},
+			b:    b256{0xFF, 0x12, 0x34},
+			want: b256{},
+		},
+		{
+			name: "xor with different values",
+			a:    b256{0xFF},
+			b:    b256{0x0F},
+			want: b256{0xF0},
+		},
+		{
+			name: "full xor operation",
+			a:    b256{0x01, 0x02, 0x03, 0x04},
+			b:    b256{0x10, 0x20, 0x30, 0x40},
+			want: b256{0x11, 0x22, 0x33, 0x44},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := xor(tt.a, tt.b)
+			if !bytes.Equal(got[:], tt.want[:]) {
+				t.Errorf("xor() = %x, want %x", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFold256(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+		want  b256
+	}{
+		{
+			name:  "empty input",
+			input: []byte{},
+			want:  b256{},
+		},
+		{
+			name:  "single byte",
+			input: []byte("a"),
+			want:  b256{97}, // 'a' = 97
+		},
+		{
+			name:  "three bytes",
+			input: []byte("abc"),
+			want:  b256{97, 98, 99}, // 'a'=97, 'b'=98, 'c'=99
+		},
+		{
+			name:  "32 bytes exact",
+			input: []byte("12345678901234567890123456789012"),
+			want: b256{49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
+				49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
+				49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
+				49, 50}, // ASCII values of "12345678901234567890123456789012"
+		},
+		{
+			name:  "33 bytes (one byte overflow)",
+			input: []byte("123456789012345678901234567890122"),
+			want: b256{3, 50, 51, 52, 53, 54, 55, 56, 57, 48,
+				49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
+				49, 50, 51, 52, 53, 54, 55, 56, 57, 48,
+				49, 50}, // '1' XOR '2' = 49 XOR 50 = 3
+		},
+		{
+			name:  "64 bytes (two identical chunks)",
+			input: []byte("1234567890123456789012345678901212345678901234567890123456789012"),
+			want:  b256{}, // XOR of two identical chunks = all zeros
+		},
+		{
+			name:  "65 bytes",
+			input: []byte("12345678901234567890123456789012123456789012345678901234567890121"),
+			want:  b256{49}, // Only first byte is '1' (49), rest zeros from XOR
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fold256(tt.input)
+			if !bytes.Equal(got[:], tt.want[:]) {
+				t.Errorf("fold256(%q) = %x, want %x", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNext256(t *testing.T) {
+	tests := []struct {
+		name string
+		ent  b256
+		last b256
+		want b256
+	}{
+		{
+			name: "all zeros",
+			ent:  b256{},
+			last: b256{},
+			want: b256{
+				0x66, 0x68, 0x7a, 0xad, 0xf8, 0x62, 0xbd, 0x77,
+				0x6c, 0x8f, 0xc1, 0x8b, 0x8e, 0x9f, 0x8e, 0x20,
+				0x08, 0x97, 0x14, 0x85, 0x6e, 0xe2, 0x33, 0xb3,
+				0x90, 0x2a, 0x59, 0x1d, 0x0d, 0x5f, 0x29, 0x25,
+			}, // SHA256 of all zeros
+		},
+		{
+			name: "entropy with first byte 0xFF",
+			ent:  b256{0xFF},
+			last: b256{},
+			want: b256{
+				0xd2, 0x2f, 0x8e, 0x34, 0x50, 0x65, 0x57, 0x84,
+				0x85, 0x38, 0x79, 0xc7, 0xec, 0xfe, 0xe4, 0xff,
+				0x36, 0x19, 0x23, 0x52, 0xf6, 0xff, 0xe0, 0xd4,
+				0x05, 0x93, 0xde, 0xe5, 0x6f, 0x58, 0x33, 0x50,
+			}, // SHA256 of [0xFF, 0, 0, ...]
+		},
+		{
+			name: "with non-zero last",
+			ent:  b256{0x01},
+			last: b256{0x02},
+			want: b256{
+				0x91, 0xd3, 0x82, 0x7f, 0x05, 0x2f, 0x5a, 0x4b,
+				0x44, 0xd5, 0xfe, 0x2b, 0xed, 0x65, 0x7c, 0x75,
+				0x22, 0x47, 0x36, 0x5d, 0x94, 0xf8, 0x0a, 0x33,
+				0xcb, 0x09, 0xc1, 0x43, 0x6a, 0x16, 0xb1, 0x25,
+			}, // SHA256 of (0x01 XOR 0x02) = SHA256 of [0x03, 0, 0, ...]
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := next256(tt.ent, tt.last)
+			if !bytes.Equal(got[:], tt.want[:]) {
+				t.Errorf("next256() = %x, want %x", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNext256Deterministic(t *testing.T) {
+	// Test that same inputs always produce same outputs
+	ent := b256{0xAB, 0xCD}
+	last := b256{0x12, 0x34}
+
+	result1 := next256(ent, last)
+	result2 := next256(ent, last)
+
+	if !bytes.Equal(result1[:], result2[:]) {
+		t.Errorf("next256 not deterministic: %x != %x", result1, result2)
+	}
+}
+
+func TestNext256Chaining(t *testing.T) {
+	// Test that chaining produces different outputs
+	ent := b256{0x42}
+
+	result1 := next256(ent, b256{})
+	result2 := next256(ent, result1)
+	result3 := next256(ent, result2)
+
+	if bytes.Equal(result1[:], result2[:]) {
+		t.Errorf("next256 chaining produced same output: %x", result1)
+	}
+	if bytes.Equal(result2[:], result3[:]) {
+		t.Errorf("next256 chaining produced same output: %x", result2)
+	}
+	if bytes.Equal(result1[:], result3[:]) {
+		t.Errorf("next256 chaining produced same output: %x", result1)
+	}
+}


### PR DESCRIPTION
Includes #1.
Interesting commit: [`1423de6` (#2)](https://github.com/jaekwon/openpgp/pull/2/commits/1423de6a95370c1eee54815e4c18b6e2ba133e5e).

---

Continues making the repo more contribution friendly.
My 2 next steps are:
- to challenge the entropy source format and entropy loss
- to experiment with deterministic rsa key generation

---

No flag passed, help suggests compatible entropy sources.

```console
$ openpgp  go install . && openpgp                                                                                                                                                                                                                              
ERROR: Missing entropy. Use -entropy flag to provide entropy string.                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                       
Usage: openpgp [OPTIONS]                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                       
Options:                                                                                                                                                                                                                                                               
  -bits int                                                                                                                                                                                                                                                            
        RSA key size in bits (default: 8192) (default 8192)                                                                                                                                                                                                            
  -entropy string                                                                                                                                                                                                                                                      
        Entropy string (dice rolls or card shuffle)                                                                                                                                                                                                                    
  -help                                                                                                                                                                                                                                                                
        Show help message                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                       
Examples:                                                                                                                                                                                                                                                              
  D20 dice (42 rolls):                                                                                                                                                                                                                                                 
    openpgp -entropy "4 2 20 15 8 12 3 19 7 11 16 5 14 9 1 18 10 6 13 17 20 8 15 3 11 7 19 2 14 5 16 12 9 4 1 18 6 10 13 17 20 7"                                                                                                                                      
                                                                                                                                                                                                                                                                       
  Card shuffle (52 cards):                                                                                                                                                                                                                                             
    openpgp -entropy "As 4d Jh Kc Td 9h 2s 7c Qd 3h 8s Ac 5d Kh 6c Js 10h 4s 9c Ad 2h 7d Qs 3c 8h Kd 5s Jc Ah 6d 10s 4h 9d 2c 7h Qc 3d 8c Ks 5h Jd As 6s 10c 4c 9s 2d 7s Qh 3s 8d 10d"                                                                                 
                                                                                                                                                                                                                                                                       
SECURITY WARNING: In production, entropy should NEVER be passed as command-line                                                                                                                                                                                        
                  arguments as they are visible in process lists and shell history!        
```

---

With a provided entropy:

```console
$ go install . && openpgp -debug -entropy "4 2 20 15 8 12 3 19 7 11 16 5 14 9 1 18 10 6 13 17 20 8 15 3 11 7 19 2 14 5 16 12 9 4 1 18 6 10 13 17 20 7"                                                                                                        
================================================================================                                                                                                                                                                                       
DEVELOPMENT MODE WARNING:                                                                                                                                                                                                                                              
- Entropy is being passed via command-line argument (INSECURE!)                                                                                                                                                                                                        
- This is ONLY for development/testing purposes                                                                                                                                                                                                                        
- Production version will read entropy securely from stdin                                                                                                                                                                                                             
- Command-line arguments are visible in process lists and shell history!                                                                                                                                                                                               
================================================================================                                                                                                                                                                                       
                                                                                                                                                                                                                                                                       
Key size: 8192 bits                                                                                                                                                                                                                                                    
Entropy: 4 2 20 15 8 12 3 19 7 11 16 5 14 9 1 18 10 6 13 17 20 8 15 3 11 7 19 2 14 5 16 12 9 4 1 18 6 10 13 17 20 7                                                                                                                                                    
                                                                                                                                                                                                                                                                       
DEBUG: === Entropy Processing Steps ===                                                                                                                                                                                                                                
DEBUG: Input entropy string: "4 2 20 15 8 12 3 19 7 11 16 5 14 9 1 18 10 6 13 17 20 8 15 3 11 7 19 2 14 5 16 12 9 4 1 18 6 10 13 17 20 7"                                                                                                                              
DEBUG: Input length: 106 bytes                                                                                                                                                                                                                                         
DEBUG: Input bytes (hex): 34203220323020313520382031322033203139203720313120313620352031342039203120313820313020362031332031372032302038203135203320313120372031392032203134203520313620313220392034203120313820362031302031332031372032302037                         
                                                                                                                                                                                                                                                                       
DEBUG: === fold256 Processing ===                                                                                                                                                                                                                                      
DEBUG: Folding 106 bytes into 32 bytes                                                                                                                                                                                                                                 
DEBUG: Number of 32-byte chunks: 4                                                                                                                                                                                                                                     
DEBUG: Chunk 0 (bytes 0-31): 3420322032302031352038203132203320313920372031312031362035203134                                                                                                                                                                          
DEBUG: Chunk 1 (bytes 32-63): 2039203120313820313020362031332031372032302038203135203320313120                                                                                                                                                                         
DEBUG: Chunk 2 (bytes 64-95): 3720313920322031342035203136203132203920342031203138203620313020                                                                                                                                                                         
DEBUG: Chunk 3 (bytes 96-105): 31332031372032302037                                                                                                                                                                                                                    
DEBUG: fold256 result: 120a031905130a1010072d36203533222326203233203831203c362535203034                                                                                                                                                                                
                                                                                                                                                                                                                                                                       
DEBUG: === next256 PRNG Processing ===                                                                                                                                                                                                                                 
DEBUG: Initial entropy (ent): 120a031905130a1010072d36203533222326203233203831203c362535203034                                                                                                                                                                         
                                                                                                                                                                                                                                                                       
DEBUG: === RSA Key Generation ===                                                                                                                                                                                                                                      
DEBUG: Generating 8192-bit RSA key...                                                                                                                                                                                                                                  
DEBUG: Initial last value: 0000000000000000000000000000000000000000000000000000000000000000                                                                                                                                                                            
DEBUG: First next256 call:                                                                                                                                                                                                                                             
DEBUG:   ent XOR last = 120a031905130a1010072d36203533222326203233203831203c362535203034                                                                                                                                                                               
DEBUG:   SHA256 result = 4e3362137873507b391b29977f6d27fa7a9b5bf0ab299c6268575ebbbfa05839                                                                                                                                                                              
DEBUG: Iteration 1: wrote 32 bytes, total: 32                                                                                                                                                                                                                          
DEBUG: Iteration 2: wrote 32 bytes, total: 64                                                                                                                                                                                                                          
DEBUG: Iteration 3: wrote 32 bytes, total: 96                                                                                                                                                                                                                          
D EBUG: RSA key generation complete                                                                                                                                                                                                                                     
DEBUG: Public key modulus (first 32 bytes): a5dd9f03f711da59e722121134200c5c8d13a945fbaf2e5c52ccce64f659a347...                                                                                                                                                        
                                                                                                                                                                                                                                                                       
-----BEGIN PRIVATE KEY-----                                                                                                                                                                                                                                            
MIISRAIBADANBgkqhkiG9w0BAQEFAASCEi4wghIqAgEAAoIEAQCl3Z8D9xHaWeci                                                                                                                                                                                                       
EhE0IAxcjROpRfuvLlxSzM5k9lmjR8CYNTIOFytl2DLjZhS8o+zKVLNk/6yj8Wxu                                                                                                                                                                                                       
Q8EcFZ7spG2Lgn5/GXAmQodqZXX1pn+2o/3nkR0PtfRpV/A+hBBv5aC8tXLYzLji                                                                                                                                                                                                       
26ElYDHN0ZqJTpSHkWytJ6jEdtXIigyoa/a9uOkEhlAhh6tFQkg9ja42bv1ueOrb                                                                                                                                                                                                       
bhBOFcsDEbTJ4U2T0yGMtU8jTct5HxyotGefnLM/FJycJtf29AEayYLpQMY1vWvt                                                                                                                                                                                                       
Vrcvd6vJk8V6f+IzEiECI0pidxBY1f/fC105K312pdvLIrku1I7cH1uuvGWbq+KV                                                                                                                                                                                                       
DzJkIX2EYNbyEBaHgdGQNoghIcAvXDdr4EK5yJxxdi/xbX0kBM416Zej/1wSGWK2                                                                                                                                                                                                       
zNDeiaVyR1XlWORHjRSdJEffbAg1a2CgwpLyvRr0/98C/ElQ+YDMyQLwNuyV8ujp                                                                                                                                                                                                       
b0Lv0zvoJi3KsmRCLWtTrnXQ3xV6Lrb6UuR37XvareTQwKTLWkrv+vwvFVwzW7P+     
…                                                              
```